### PR TITLE
Updated to work with new Keyvault

### DIFF
--- a/.jx/secret/mapping/secret-mappings.yaml
+++ b/.jx/secret/mapping/secret-mappings.yaml
@@ -88,10 +88,12 @@ spec:
     mappings:
     - key: jx-admin-user
       name: BASIC_AUTH_USER
-      property: username
+    - key: jx-admin-user
+      name: usermame
+    - key: jx-admin-user
+      name: password
     - key: jx-admin-user
       name: BASIC_AUTH_PASS
-      property: password
     name: jenkins-x-chartmuseum
   - backendType: azureKeyVault
     mappings:


### PR DESCRIPTION
Not sure if this PR is the best way of doing is but I noticed that the secret jenkins-x-chartmuseum silently fails after creation. By removing the properties tags from the mappings the secret got populated, but then all services' builds failed because Chartmuseum couldn't find neither the username nor the password. By adding two redundant fields I managed to get everything working, but I feel like this is a temporary fix. You might want to look at it better, thanks.